### PR TITLE
Fix the-top-level-classloader operating on wrong classloader

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/common "1.0.2"
+(defproject metabase/common "1.0.3"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/common"
   :min-lein-version "2.5.0"

--- a/src/metabase/common/classloader.clj
+++ b/src/metabase/common/classloader.clj
@@ -119,9 +119,10 @@
   ultimately have access to that URL."
   (^DynamicClassLoader []
    (the-top-level-classloader (the-classloader)))
+
   (^DynamicClassLoader [^DynamicClassLoader classloader]
    (some #(when (instance? DynamicClassLoader %) %)
-         (classloader-hierarchy (.getContextClassLoader (Thread/currentThread))))))
+         (classloader-hierarchy classloader))))
 
 (defonce ^:private already-added (atom #{}))
 


### PR DESCRIPTION
1-arity operated on current thread's context classloader instead of
the supplied arg.